### PR TITLE
Add basic Edit Scrum View with modal presentation

### DIFF
--- a/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		417FE28B2CBA104B00D89141 /* TrailingIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417FE28A2CBA104B00D89141 /* TrailingIconLabelStyle.swift */; };
 		41A67E992CBF550A007033F6 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E982CBF550A007033F6 /* DetailView.swift */; };
+		41A67E9B2CC0243B007033F6 /* DetailEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E9A2CC0243B007033F6 /* DetailEditView.swift */; };
 		41B3B6292CBCAD4800420893 /* ScrumsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B3B6282CBCAD4800420893 /* ScrumsView.swift */; };
 		41DA23D82CB8BF5B004ABF49 /* ScrumdingerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */; };
 		41DA23DA2CB8BF5B004ABF49 /* MeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D92CB8BF5B004ABF49 /* MeetingView.swift */; };
@@ -22,6 +23,7 @@
 /* Begin PBXFileReference section */
 		417FE28A2CBA104B00D89141 /* TrailingIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingIconLabelStyle.swift; sourceTree = "<group>"; };
 		41A67E982CBF550A007033F6 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		41A67E9A2CC0243B007033F6 /* DetailEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditView.swift; sourceTree = "<group>"; };
 		41B3B6282CBCAD4800420893 /* ScrumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumsView.swift; sourceTree = "<group>"; };
 		41DA23D42CB8BF5B004ABF49 /* Scrumdinger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Scrumdinger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumdingerApp.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 				417FE28A2CBA104B00D89141 /* TrailingIconLabelStyle.swift */,
 				41B3B6282CBCAD4800420893 /* ScrumsView.swift */,
 				41A67E982CBF550A007033F6 /* DetailView.swift */,
+				41A67E9A2CC0243B007033F6 /* DetailEditView.swift */,
 			);
 			path = Scrumdinger;
 			sourceTree = "<group>";
@@ -167,6 +170,7 @@
 			files = (
 				41DA241D2CB9A179004ABF49 /* DailyScrum.swift in Sources */,
 				41A67E992CBF550A007033F6 /* DetailView.swift in Sources */,
+				41A67E9B2CC0243B007033F6 /* DetailEditView.swift in Sources */,
 				417FE28B2CBA104B00D89141 /* TrailingIconLabelStyle.swift in Sources */,
 				41DA23E82CB99EC6004ABF49 /* Theme.swift in Sources */,
 				41B3B6292CBCAD4800420893 /* ScrumsView.swift in Sources */,

--- a/Scrumdinger/Scrumdinger/DetailEditView.swift
+++ b/Scrumdinger/Scrumdinger/DetailEditView.swift
@@ -16,11 +16,12 @@ struct DetailEditView: View {
             Section(header: Text("Meeting Info")) {
                 TextField("Title", text: $scrum.title)
                 HStack {
-                    Slider(value: $scrum.lengthInMinutesAsDouble,
-                           in: 5...30,
-                           step: 1) {
+                    Slider(value: $scrum.lengthInMinutesAsDouble, in: 5...30, step: 1) {
                         Text("Length")
+                            .accessibilityHidden(/*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
+                            
                     }
+                    .accessibilityLabel("\(scrum.lengthInMinutes) minutes")
                     Spacer()
                     Text("\(scrum.lengthInMinutes) minutes")
                 }
@@ -42,6 +43,7 @@ struct DetailEditView: View {
                         newAttendeeName = ""
                     }) {
                         Image(systemName: "plus.circle.fill")
+                            .accessibilityLabel("add attendee")
                     }
                     .disabled(newAttendeeName.isEmpty)
                 }

--- a/Scrumdinger/Scrumdinger/DetailEditView.swift
+++ b/Scrumdinger/Scrumdinger/DetailEditView.swift
@@ -1,0 +1,24 @@
+//
+//  DetailEditView.swift
+//  Scrumdinger
+//
+//  Created by justin richardson on 2024-10-16.
+//
+
+import SwiftUI
+
+struct DetailEditView: View {
+    @State private var scrum = DailyScrum.emptyScrum
+    
+    var body: some View {
+        Form {
+            Section(header: Text("Meeting Info")) {
+                TextField("Title", text: $scrum.title)
+            }
+        }
+    }
+}
+
+#Preview {
+    DetailEditView()
+}

--- a/Scrumdinger/Scrumdinger/DetailEditView.swift
+++ b/Scrumdinger/Scrumdinger/DetailEditView.swift
@@ -14,6 +14,15 @@ struct DetailEditView: View {
         Form {
             Section(header: Text("Meeting Info")) {
                 TextField("Title", text: $scrum.title)
+                HStack {
+                    Slider(value: $scrum.lengthInMinutesAsDouble,
+                           in: 5...30,
+                           step: 1) {
+                        Text("Length")
+                    }
+                    Spacer()
+                    Text("\(scrum.lengthInMinutes) minutes")
+                }
             }
         }
     }

--- a/Scrumdinger/Scrumdinger/DetailEditView.swift
+++ b/Scrumdinger/Scrumdinger/DetailEditView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct DetailEditView: View {
     @State private var scrum = DailyScrum.emptyScrum
+    @State private var newAttendeeName: String = ""
     
     var body: some View {
         Form {
@@ -22,6 +23,27 @@ struct DetailEditView: View {
                     }
                     Spacer()
                     Text("\(scrum.lengthInMinutes) minutes")
+                }
+            }
+            
+            Section(header: Text("Attendees")) {
+                ForEach(scrum.attendees) { attendee in
+                    Text(attendee.name)
+                }
+                .onDelete { indices in
+                    scrum.attendees.remove(atOffsets: indices)
+                }
+                
+                HStack {
+                    TextField("New Attendee", text: $newAttendeeName)
+                    Button(action: {
+                        let attendee = DailyScrum.Attendee(name: newAttendeeName)
+                        scrum.attendees.append(attendee)
+                        newAttendeeName = ""
+                    }) {
+                        Image(systemName: "plus.circle.fill")
+                    }
+                    .disabled(newAttendeeName.isEmpty)
                 }
             }
         }

--- a/Scrumdinger/Scrumdinger/DetailView.swift
+++ b/Scrumdinger/Scrumdinger/DetailView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct DetailView: View {
     var scrum: DailyScrum
     
+    @State private var isDetailViewPresented: Bool = false
+    
     var body: some View {
         List {
             Section(header: Text("Meeting Info")) {
@@ -43,6 +45,33 @@ struct DetailView: View {
             }
         }
         .navigationTitle(scrum.title)
+        .toolbar(content: {
+            Button("Edit") {
+                isDetailViewPresented.toggle()
+            }
+        })
+        .sheet(isPresented: $isDetailViewPresented,
+               onDismiss: {},
+               content: {
+            NavigationStack {
+                DetailEditView()
+                    .navigationTitle(scrum.title)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") {
+                                isDetailViewPresented.toggle()
+                            }
+                        }
+                        
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") {
+                                isDetailViewPresented.toggle()
+                            }
+                        }
+                    }
+            }
+        }
+        )
     }
 }
 

--- a/Scrumdinger/Scrumdinger/Models/DailyScrum.swift
+++ b/Scrumdinger/Scrumdinger/Models/DailyScrum.swift
@@ -12,6 +12,15 @@ struct DailyScrum: Identifiable {
     var title: String
     var attendees: [Attendee]
     var lengthInMinutes: Int
+    var lengthInMinutesAsDouble: Double {
+        get {
+            Double(lengthInMinutes)
+        }
+        
+        set {
+            lengthInMinutes = Int(newValue)
+        }
+    }
     var theme: Theme
     
     init(id: UUID = UUID(), title: String, attendees: [String], lengthInMinutes: Int, theme: Theme) {

--- a/Scrumdinger/Scrumdinger/Models/DailyScrum.swift
+++ b/Scrumdinger/Scrumdinger/Models/DailyScrum.swift
@@ -33,6 +33,10 @@ extension DailyScrum {
             self.name = name
         }
     }
+    
+   static var emptyScrum: DailyScrum {
+        DailyScrum(title: "", attendees: [], lengthInMinutes: 0, theme: .sky)
+    }
 }
 
 extension DailyScrum {


### PR DESCRIPTION
### **Description**  
This PR introduces a new **Edit Scrum View**, allowing users to edit details of their selected scrum. Key points of this implementation include:

- **Edit Scrum View**: Presented modally, the view provides an interface for users to modify scrum details.
- This PR establishes **basic functionality** for the Edit View, without any data bindings to reflect changes in the parent view yet.
- **Follow-up work**: Data bindings to synchronize changes with the parent view will be handled in a future PR.
- No tests have been included for this functionality yet.

---

### **How to Test**
1. **Access the Edit Scrum View**:
   - Launch the app and navigate to the Edit Scrum View from the DetailsView.
   - Confirm the view is presented modally as expected.
2. **Verify basic UI functionality**:
   - Ensure the edit fields are available and interactable, but note that changes will not yet reflect in the parent view.

---

### **Screenshots** (if applicable)  
https://github.com/user-attachments/assets/0eb73aa7-a467-4a19-a1ad-28bde5c8c27e

---

### **Checklist**  
- [x] Modal presentation of the Edit Scrum View works correctly.  
- [ ] Data bindings for the Edit Scrum View will be completed in a follow-up PR.  
- [ ] No tests added yet (to be included in a future PR).
