### PR TITLE
Add Bindings to enable data sync between ListView, DetailView, and EditView

### DIFF
--- a/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		41A67E992CBF550A007033F6 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E982CBF550A007033F6 /* DetailView.swift */; };
 		41A67E9B2CC0243B007033F6 /* DetailEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E9A2CC0243B007033F6 /* DetailEditView.swift */; };
 		41A67E9D2CC1903F007033F6 /* ThemeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E9C2CC1903F007033F6 /* ThemeView.swift */; };
+		41A67E9F2CC19610007033F6 /* ThemePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E9E2CC19610007033F6 /* ThemePicker.swift */; };
 		41B3B6292CBCAD4800420893 /* ScrumsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B3B6282CBCAD4800420893 /* ScrumsView.swift */; };
 		41DA23D82CB8BF5B004ABF49 /* ScrumdingerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */; };
 		41DA23DA2CB8BF5B004ABF49 /* MeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D92CB8BF5B004ABF49 /* MeetingView.swift */; };
@@ -26,6 +27,7 @@
 		41A67E982CBF550A007033F6 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		41A67E9A2CC0243B007033F6 /* DetailEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditView.swift; sourceTree = "<group>"; };
 		41A67E9C2CC1903F007033F6 /* ThemeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeView.swift; sourceTree = "<group>"; };
+		41A67E9E2CC19610007033F6 /* ThemePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePicker.swift; sourceTree = "<group>"; };
 		41B3B6282CBCAD4800420893 /* ScrumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumsView.swift; sourceTree = "<group>"; };
 		41DA23D42CB8BF5B004ABF49 /* Scrumdinger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Scrumdinger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumdingerApp.swift; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 				41A67E982CBF550A007033F6 /* DetailView.swift */,
 				41A67E9A2CC0243B007033F6 /* DetailEditView.swift */,
 				41A67E9C2CC1903F007033F6 /* ThemeView.swift */,
+				41A67E9E2CC19610007033F6 /* ThemePicker.swift */,
 			);
 			path = Scrumdinger;
 			sourceTree = "<group>";
@@ -171,6 +174,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				41A67E9F2CC19610007033F6 /* ThemePicker.swift in Sources */,
 				41DA241D2CB9A179004ABF49 /* DailyScrum.swift in Sources */,
 				41A67E992CBF550A007033F6 /* DetailView.swift in Sources */,
 				41A67E9B2CC0243B007033F6 /* DetailEditView.swift in Sources */,

--- a/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		417FE28B2CBA104B00D89141 /* TrailingIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417FE28A2CBA104B00D89141 /* TrailingIconLabelStyle.swift */; };
 		41A67E992CBF550A007033F6 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E982CBF550A007033F6 /* DetailView.swift */; };
 		41A67E9B2CC0243B007033F6 /* DetailEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E9A2CC0243B007033F6 /* DetailEditView.swift */; };
+		41A67E9D2CC1903F007033F6 /* ThemeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67E9C2CC1903F007033F6 /* ThemeView.swift */; };
 		41B3B6292CBCAD4800420893 /* ScrumsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B3B6282CBCAD4800420893 /* ScrumsView.swift */; };
 		41DA23D82CB8BF5B004ABF49 /* ScrumdingerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */; };
 		41DA23DA2CB8BF5B004ABF49 /* MeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D92CB8BF5B004ABF49 /* MeetingView.swift */; };
@@ -24,6 +25,7 @@
 		417FE28A2CBA104B00D89141 /* TrailingIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingIconLabelStyle.swift; sourceTree = "<group>"; };
 		41A67E982CBF550A007033F6 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		41A67E9A2CC0243B007033F6 /* DetailEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditView.swift; sourceTree = "<group>"; };
+		41A67E9C2CC1903F007033F6 /* ThemeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeView.swift; sourceTree = "<group>"; };
 		41B3B6282CBCAD4800420893 /* ScrumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumsView.swift; sourceTree = "<group>"; };
 		41DA23D42CB8BF5B004ABF49 /* Scrumdinger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Scrumdinger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumdingerApp.swift; sourceTree = "<group>"; };
@@ -77,6 +79,7 @@
 				41B3B6282CBCAD4800420893 /* ScrumsView.swift */,
 				41A67E982CBF550A007033F6 /* DetailView.swift */,
 				41A67E9A2CC0243B007033F6 /* DetailEditView.swift */,
+				41A67E9C2CC1903F007033F6 /* ThemeView.swift */,
 			);
 			path = Scrumdinger;
 			sourceTree = "<group>";
@@ -176,6 +179,7 @@
 				41B3B6292CBCAD4800420893 /* ScrumsView.swift in Sources */,
 				41DA23DA2CB8BF5B004ABF49 /* MeetingView.swift in Sources */,
 				41DA23D82CB8BF5B004ABF49 /* ScrumdingerApp.swift in Sources */,
+				41A67E9D2CC1903F007033F6 /* ThemeView.swift in Sources */,
 				41DA241F2CB9A2A6004ABF49 /* CardView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Scrumdinger/Scrumdinger/DetailEditView.swift
+++ b/Scrumdinger/Scrumdinger/DetailEditView.swift
@@ -25,6 +25,7 @@ struct DetailEditView: View {
                     Spacer()
                     Text("\(scrum.lengthInMinutes) minutes")
                 }
+                ThemePicker(selection: $scrum.theme)
             }
             
             Section(header: Text("Attendees")) {
@@ -53,5 +54,7 @@ struct DetailEditView: View {
 }
 
 #Preview {
-    DetailEditView()
+    NavigationStack {
+        DetailEditView()
+    }
 }

--- a/Scrumdinger/Scrumdinger/DetailEditView.swift
+++ b/Scrumdinger/Scrumdinger/DetailEditView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DetailEditView: View {
-    @State private var scrum = DailyScrum.emptyScrum
+    @Binding var scrum: DailyScrum
     @State private var newAttendeeName: String = ""
     
     var body: some View {
@@ -18,7 +18,7 @@ struct DetailEditView: View {
                 HStack {
                     Slider(value: $scrum.lengthInMinutesAsDouble, in: 5...30, step: 1) {
                         Text("Length")
-                            .accessibilityHidden(/*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
+                            .accessibilityHidden(true)
                             
                     }
                     .accessibilityLabel("\(scrum.lengthInMinutes) minutes")
@@ -55,6 +55,6 @@ struct DetailEditView: View {
 
 #Preview {
     NavigationStack {
-        DetailEditView()
+        DetailEditView(scrum: .constant(DailyScrum.mockData[0]))
     }
 }

--- a/Scrumdinger/Scrumdinger/DetailView.swift
+++ b/Scrumdinger/Scrumdinger/DetailView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct DetailView: View {
-    var scrum: DailyScrum
+    @Binding var scrum: DailyScrum
     
+    @State private var editingScrum = DailyScrum.emptyScrum
     @State private var isDetailViewPresented: Bool = false
     
     var body: some View {
@@ -48,13 +49,14 @@ struct DetailView: View {
         .toolbar(content: {
             Button("Edit") {
                 isDetailViewPresented.toggle()
+                editingScrum = scrum
             }
         })
         .sheet(isPresented: $isDetailViewPresented,
                onDismiss: {},
                content: {
             NavigationStack {
-                DetailEditView()
+                DetailEditView(scrum: $editingScrum)
                     .navigationTitle(scrum.title)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -66,6 +68,7 @@ struct DetailView: View {
                         ToolbarItem(placement: .confirmationAction) {
                             Button("Done") {
                                 isDetailViewPresented.toggle()
+                                scrum = editingScrum
                             }
                         }
                     }
@@ -78,6 +81,6 @@ struct DetailView: View {
 #Preview {
     NavigationStack {
         let scrum = DailyScrum.mockData[0]
-        DetailView(scrum: scrum)
+        DetailView(scrum: .constant(scrum))
     }
 }

--- a/Scrumdinger/Scrumdinger/Models/Theme.swift
+++ b/Scrumdinger/Scrumdinger/Models/Theme.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum Theme: String {
+enum Theme: String, CaseIterable, Identifiable {
     case bubblegum
     case buttercup
     case indigo
@@ -38,5 +38,9 @@ enum Theme: String {
     
     var name: String {
         rawValue.capitalized
+    }
+    
+    var id: String {
+        name
     }
 }

--- a/Scrumdinger/Scrumdinger/ScrumdingerApp.swift
+++ b/Scrumdinger/Scrumdinger/ScrumdingerApp.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 @main
 struct ScrumdingerApp: App {
+    @State private var scrums = DailyScrum.mockData
+    
     var body: some Scene {
         WindowGroup {
-            ScrumsView(scrums: DailyScrum.mockData)
+            ScrumsView(scrums: $scrums)
         }
     }
 }

--- a/Scrumdinger/Scrumdinger/ScrumsView.swift
+++ b/Scrumdinger/Scrumdinger/ScrumsView.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct ScrumsView: View {
-    let scrums: [DailyScrum]
+    @Binding var scrums: [DailyScrum]
     
     var body: some View {
         NavigationStack {
-            List(scrums) { scrum in
-                NavigationLink(destination: DetailView(scrum: scrum)) {
+            List($scrums) { $scrum in
+                NavigationLink(destination: DetailView(scrum: $scrum)) {
                     CardView(scrum: scrum)
                 }
                 .listRowBackground(scrum.theme.mainColor)
@@ -30,5 +30,5 @@ struct ScrumsView: View {
 }
 
 #Preview {
-    ScrumsView(scrums: DailyScrum.mockData)
+    ScrumsView(scrums: .constant(DailyScrum.mockData))
 }

--- a/Scrumdinger/Scrumdinger/ThemePicker.swift
+++ b/Scrumdinger/Scrumdinger/ThemePicker.swift
@@ -1,0 +1,26 @@
+//
+//  ThemePicker.swift
+//  Scrumdinger
+//
+//  Created by justin richardson on 2024-10-17.
+//
+
+import SwiftUI
+
+struct ThemePicker: View {
+    @Binding var selection: Theme
+    
+    var body: some View {
+        Picker("Theme", selection: $selection) {
+            ForEach(Theme.allCases) { theme in
+                ThemeView(theme: theme)
+                    .tag(theme)
+            }
+        }
+        .pickerStyle(.navigationLink)
+    }
+}
+
+#Preview {
+    ThemePicker(selection: .constant(.periwinkle))
+}

--- a/Scrumdinger/Scrumdinger/ThemeView.swift
+++ b/Scrumdinger/Scrumdinger/ThemeView.swift
@@ -1,0 +1,25 @@
+//
+//  ThemeView.swift
+//  Scrumdinger
+//
+//  Created by justin richardson on 2024-10-17.
+//
+
+import SwiftUI
+
+struct ThemeView: View {
+    let theme: Theme
+    
+    var body: some View {
+        Text("\(theme.name)")
+            .padding(4)
+            .frame(maxWidth: .infinity)
+            .background(theme.mainColor)
+            .foregroundStyle(theme.accentColor)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+}
+
+#Preview {
+    ThemeView(theme: .buttercup)
+}


### PR DESCRIPTION
### **Description**  
This PR adds **Bindings** to the ListView, DetailView, and EditView to enable data synchronization for the selected scrum. Key changes include:

- **Binding the scrum data** across the views so that updates made in the **EditView** are reflected in the parent views (ListView and DetailView).
- The changes to the scrum are saved when the user presses the **Done** button in the EditView.
- This ensures that any updates to the selected scrum are immediately visible throughout the app once they are confirmed.

---

### **How to Test**
1. **Edit a Scrum**:
   - Navigate to the EditView from the DetailView.
   - Modify the scrum details and press the **Done** button.
   - Confirm that the updated details are displayed in both the **DetailView** and the **ListView**.

2. **Verify Data Synchronization**:
   - Ensure the changes to the selected scrum persist across all views after editing.

---

### **Screenshots** (if applicable)  
https://github.com/user-attachments/assets/de5052d2-f9e8-4f02-ab70-bd402fa5db06

---

### **Checklist**  
- [x] Bindings for scrum data between ListView, DetailView, and EditView work as expected.  
- [x] Changes made in EditView are reflected in parent views upon pressing Done.
