### PR TITLE
Add NewScrumSheet for creating new scrums in ScrumsView

### DIFF
--- a/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
+++ b/Scrumdinger/Scrumdinger.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		41A67EA72CC88FDA007033F6 /* MeetingFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67EA62CC88FDA007033F6 /* MeetingFooterView.swift */; };
 		41A67EAA2CC950D9007033F6 /* AVPlayer+Ding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67EA92CC950CC007033F6 /* AVPlayer+Ding.swift */; };
 		41A67EAD2CC95CA6007033F6 /* ding.wav in Resources */ = {isa = PBXBuildFile; fileRef = 41A67EAC2CC95CA6007033F6 /* ding.wav */; };
+		41A67EB02CD31BA2007033F6 /* NewScrumSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A67EAF2CD31BA2007033F6 /* NewScrumSheet.swift */; };
 		41B3B6292CBCAD4800420893 /* ScrumsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B3B6282CBCAD4800420893 /* ScrumsView.swift */; };
 		41DA23D82CB8BF5B004ABF49 /* ScrumdingerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */; };
 		41DA23DA2CB8BF5B004ABF49 /* MeetingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DA23D92CB8BF5B004ABF49 /* MeetingView.swift */; };
@@ -40,6 +41,7 @@
 		41A67EA62CC88FDA007033F6 /* MeetingFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingFooterView.swift; sourceTree = "<group>"; };
 		41A67EA92CC950CC007033F6 /* AVPlayer+Ding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayer+Ding.swift"; sourceTree = "<group>"; };
 		41A67EAC2CC95CA6007033F6 /* ding.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = ding.wav; sourceTree = "<group>"; };
+		41A67EAF2CD31BA2007033F6 /* NewScrumSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewScrumSheet.swift; sourceTree = "<group>"; };
 		41B3B6282CBCAD4800420893 /* ScrumsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumsView.swift; sourceTree = "<group>"; };
 		41DA23D42CB8BF5B004ABF49 /* Scrumdinger.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Scrumdinger.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41DA23D72CB8BF5B004ABF49 /* ScrumdingerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrumdingerApp.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 				41A67EA22CC87B1C007033F6 /* ScrumProgressViewStyle.swift */,
 				41A67EA62CC88FDA007033F6 /* MeetingFooterView.swift */,
 				417FE28A2CBA104B00D89141 /* TrailingIconLabelStyle.swift */,
+				41A67EAF2CD31BA2007033F6 /* NewScrumSheet.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -223,6 +226,7 @@
 				41A67EA52CC881D3007033F6 /* ScrumTimer.swift in Sources */,
 				41DA241D2CB9A179004ABF49 /* DailyScrum.swift in Sources */,
 				41A67E992CBF550A007033F6 /* DetailView.swift in Sources */,
+				41A67EB02CD31BA2007033F6 /* NewScrumSheet.swift in Sources */,
 				41A67EA12CC870D3007033F6 /* MeetingHeaderView.swift in Sources */,
 				41A67E9B2CC0243B007033F6 /* DetailEditView.swift in Sources */,
 				417FE28B2CBA104B00D89141 /* TrailingIconLabelStyle.swift in Sources */,

--- a/Scrumdinger/Scrumdinger/Views/NewScrumSheet.swift
+++ b/Scrumdinger/Scrumdinger/Views/NewScrumSheet.swift
@@ -1,0 +1,18 @@
+//
+//  NewScrumSheet.swift
+//  Scrumdinger
+//
+//  Created by justin richardson on 2024-10-30.
+//
+
+import SwiftUI
+
+struct NewScrumSheet: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    NewScrumSheet()
+}

--- a/Scrumdinger/Scrumdinger/Views/NewScrumSheet.swift
+++ b/Scrumdinger/Scrumdinger/Views/NewScrumSheet.swift
@@ -8,11 +8,41 @@
 import SwiftUI
 
 struct NewScrumSheet: View {
+    @Binding var scrums: [DailyScrum]
+    @Binding var isPresentingNewScrumSheet: Bool
+    
+    @State private var newScrum = DailyScrum.emptyScrum
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationStack {
+            DetailEditView(scrum: $newScrum)
+                .toolbar {
+                    ToolbarItem(
+                        placement: .cancellationAction,
+                        content: {
+                            Button("Dismiss") {
+                                isPresentingNewScrumSheet = false
+                            }
+                        }
+                    )
+                    
+                    ToolbarItem(
+                        placement: .confirmationAction,
+                        content: {
+                            Button("Add") {
+                                scrums.append(newScrum)
+                                isPresentingNewScrumSheet = false
+                            }
+                        }
+                    )
+                }
+        }
     }
 }
 
 #Preview {
-    NewScrumSheet()
+    NewScrumSheet(
+        scrums: .constant(DailyScrum.mockData),
+        isPresentingNewScrumSheet: .constant(true)
+    )
 }

--- a/Scrumdinger/Scrumdinger/Views/ScrumsView.swift
+++ b/Scrumdinger/Scrumdinger/Views/ScrumsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ScrumsView: View {
     @Binding var scrums: [DailyScrum]
+    @State private var isPresentingNewScrumView = false
     
     var body: some View {
         NavigationStack {
@@ -20,12 +21,15 @@ struct ScrumsView: View {
             }
             .navigationTitle("Daily Scrums")
             .toolbar {
-                Button(action: {print("Add scrum!")}) {
+                Button(action: {
+                    isPresentingNewScrumView = true
+                }) {
                     Image(systemName: "plus")
                 }
                 .accessibilityLabel("New Scrum")
             }
         }
+        .sheet(isPresented: $isPresentingNewScrumView, content: { NewScrumSheet() })
     }
 }
 

--- a/Scrumdinger/Scrumdinger/Views/ScrumsView.swift
+++ b/Scrumdinger/Scrumdinger/Views/ScrumsView.swift
@@ -29,7 +29,15 @@ struct ScrumsView: View {
                 .accessibilityLabel("New Scrum")
             }
         }
-        .sheet(isPresented: $isPresentingNewScrumView, content: { NewScrumSheet() })
+        .sheet(
+            isPresented: $isPresentingNewScrumView,
+            content: {
+                NewScrumSheet(
+                    scrums: $scrums,
+                    isPresentingNewScrumSheet: $isPresentingNewScrumView
+                )
+            }
+        )
     }
 }
 


### PR DESCRIPTION
This PR introduces a **NewScrumSheet** that allows users to create a new scrum directly from the **ScrumsView**. 

Key features include:
1. **Plus Button in ScrumsView**:
   - Tapping the **plus** button in ScrumsView presents the **NewScrumSheet** modally.

2. **NewScrumSheet with DetailedScrumView**:
   - The **NewScrumSheet** leverages `DetailedScrumView` to capture the details of the new scrum.
   - Users can **add the new scrum** to persist it across views, or **discard** the sheet to return to ScrumsView without changes.

3. **Data Binding**:
   - The **scrums binding** ensures that any new scrum data is properly added and available throughout relevant views, maintaining state consistency.

---

### **How to Test**
1. **Open NewScrumSheet**:
   - In ScrumsView, tap the **plus button** to present the NewScrumSheet.

2. **Add a New Scrum**:
   - Fill in the scrum details and add the scrum. Confirm it appears in the ScrumsView and persists across views.

3. **Discard the Sheet**:
   - Tap outside the modal or use a dismiss action to close the NewScrumSheet without adding a new scrum. Confirm you return to ScrumsView without any changes.

---

### **Checklist**
- [x] Plus button in ScrumsView opens NewScrumSheet modally
- [x] DetailedScrumView captures new scrum details
- [x] Scrum binding ensures data persists across views